### PR TITLE
feat: alg usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,9 +95,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.1.tgz",
-			"integrity": "sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==",
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
+			"integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -637,9 +637,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-en_us": {
-			"version": "4.4.6",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.6.tgz",
-			"integrity": "sha512-9QFpNzyvqNkCc3QCJb2RmG87rXz2Iz3R6o9fknOyzN7HL/LRMwipuksricriPYPs+h3ZSQm4Jtgc+sX4gWY5vg==",
+			"version": "4.4.7",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.7.tgz",
+			"integrity": "sha512-hXyehIIeIAofy5LkF8PeMHqBhtNQ/qc5bQlDzxbAVB0+1FFcZlS8OUf+gHTQScDbPbVCTxXF9NB26vM+Px7mtw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -707,9 +707,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-golang": {
-			"version": "6.0.20",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.20.tgz",
-			"integrity": "sha512-b7nd9XXs+apMMzNSWorjirQsbmlwcTC0ViQJU8u+XNose3z0y7oNeEpbTPTVoN1+1sO9aOHuFwfwoOMFCDS14Q==",
+			"version": "6.0.21",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.21.tgz",
+			"integrity": "sha512-D3wG1MWhFx54ySFJ00CS1MVjR4UiBVsOWGIjJ5Av+HamnguqEshxbF9mvy+BX0KqzdLVzwFkoLBs8QeOID56HA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -898,9 +898,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-software-terms": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.0.7.tgz",
-			"integrity": "sha512-6ttSc0/EzDN44DF2Bk/37cr3IntzuNcZ4MbUy/zEhfhDMiuQoXslILpAs/9FoKEuFpsm6A+8manT2GytWwr/HA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.0.8.tgz",
+			"integrity": "sha512-VsJesitvaHZpMgNwHHms3yDsZz7LNToC2HuSAnyt1znn37ribiJF1ty0jWhVQO6fv7K4PM1KsKTJIwqBwc446g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1020,9 +1020,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.3.tgz",
-			"integrity": "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.4.tgz",
+			"integrity": "sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1037,9 +1037,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.3.tgz",
-			"integrity": "sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.4.tgz",
+			"integrity": "sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1054,9 +1054,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.3.tgz",
-			"integrity": "sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz",
+			"integrity": "sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1071,9 +1071,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.3.tgz",
-			"integrity": "sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.4.tgz",
+			"integrity": "sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1088,9 +1088,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
-			"integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.4.tgz",
+			"integrity": "sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1105,9 +1105,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.3.tgz",
-			"integrity": "sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz",
+			"integrity": "sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==",
 			"cpu": [
 				"x64"
 			],
@@ -1122,9 +1122,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.3.tgz",
-			"integrity": "sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.4.tgz",
+			"integrity": "sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1139,9 +1139,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.3.tgz",
-			"integrity": "sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz",
+			"integrity": "sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1156,9 +1156,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.3.tgz",
-			"integrity": "sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz",
+			"integrity": "sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1173,9 +1173,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.3.tgz",
-			"integrity": "sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.4.tgz",
+			"integrity": "sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1190,9 +1190,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.3.tgz",
-			"integrity": "sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.4.tgz",
+			"integrity": "sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1207,9 +1207,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.3.tgz",
-			"integrity": "sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz",
+			"integrity": "sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==",
 			"cpu": [
 				"loong64"
 			],
@@ -1224,9 +1224,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.3.tgz",
-			"integrity": "sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.4.tgz",
+			"integrity": "sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1241,9 +1241,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.3.tgz",
-			"integrity": "sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz",
+			"integrity": "sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1258,9 +1258,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.3.tgz",
-			"integrity": "sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.4.tgz",
+			"integrity": "sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1275,9 +1275,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.3.tgz",
-			"integrity": "sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz",
+			"integrity": "sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==",
 			"cpu": [
 				"s390x"
 			],
@@ -1292,9 +1292,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz",
-			"integrity": "sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.4.tgz",
+			"integrity": "sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==",
 			"cpu": [
 				"x64"
 			],
@@ -1309,9 +1309,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.3.tgz",
-			"integrity": "sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz",
+			"integrity": "sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1326,9 +1326,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.3.tgz",
-			"integrity": "sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.4.tgz",
+			"integrity": "sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==",
 			"cpu": [
 				"x64"
 			],
@@ -1343,9 +1343,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.3.tgz",
-			"integrity": "sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz",
+			"integrity": "sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1360,9 +1360,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.3.tgz",
-			"integrity": "sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.4.tgz",
+			"integrity": "sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==",
 			"cpu": [
 				"x64"
 			],
@@ -1377,9 +1377,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.3.tgz",
-			"integrity": "sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.4.tgz",
+			"integrity": "sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==",
 			"cpu": [
 				"x64"
 			],
@@ -1394,9 +1394,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.3.tgz",
-			"integrity": "sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz",
+			"integrity": "sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1411,9 +1411,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.3.tgz",
-			"integrity": "sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.4.tgz",
+			"integrity": "sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==",
 			"cpu": [
 				"ia32"
 			],
@@ -1428,9 +1428,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.3.tgz",
-			"integrity": "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz",
+			"integrity": "sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1616,16 +1616,16 @@
 			}
 		},
 		"node_modules/@gerrit0/mini-shiki": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.3.0.tgz",
-			"integrity": "sha512-frvArO0+s5Viq68uSod5SieLPVM2cLpXoQ1e07lURwgADXpL/MOypM7jPz9otks0g2DIe2YedDAeVrDyYJZRxA==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.0.tgz",
+			"integrity": "sha512-48lKoQegmfJ0iyR/jRz5OrYOSM3WewG9YWCPqUvYFEC54shQO8RsAaspaK/2PRHVVnjekRqfAFvq8pwCpIo5ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/engine-oniguruma": "^3.3.0",
-				"@shikijs/langs": "^3.3.0",
-				"@shikijs/themes": "^3.3.0",
-				"@shikijs/types": "^3.3.0",
+				"@shikijs/engine-oniguruma": "^3.4.0",
+				"@shikijs/langs": "^3.4.0",
+				"@shikijs/themes": "^3.4.0",
+				"@shikijs/types": "^3.4.0",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
@@ -2574,40 +2574,40 @@
 			}
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.3.0.tgz",
-			"integrity": "sha512-l0vIw+GxeNU7uGnsu6B+Crpeqf+WTQ2Va71cHb5ZYWEVEPdfYwY5kXwYqRJwHrxz9WH+pjSpXQz+TJgAsrkA5A==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.0.tgz",
+			"integrity": "sha512-zwcWlZ4OQuJ/+1t32ClTtyTU1AiDkK1lhtviRWoq/hFqPjCNyLj22bIg9rB7BfoZKOEOfrsGz7No33BPCf+WlQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.3.0",
+				"@shikijs/types": "3.4.0",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
 		"node_modules/@shikijs/langs": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.3.0.tgz",
-			"integrity": "sha512-zt6Kf/7XpBQKSI9eqku+arLkAcDQ3NHJO6zFjiChI8w0Oz6Jjjay7pToottjQGjSDCFk++R85643WbyINcuL+g==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.0.tgz",
+			"integrity": "sha512-bQkR+8LllaM2duU9BBRQU0GqFTx7TuF5kKlw/7uiGKoK140n1xlLAwCgXwSxAjJ7Htk9tXTFwnnsJTCU5nDPXQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.3.0"
+				"@shikijs/types": "3.4.0"
 			}
 		},
 		"node_modules/@shikijs/themes": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.3.0.tgz",
-			"integrity": "sha512-tXeCvLXBnqq34B0YZUEaAD1lD4lmN6TOHAhnHacj4Owh7Ptb/rf5XCDeROZt2rEOk5yuka3OOW2zLqClV7/SOg==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.0.tgz",
+			"integrity": "sha512-YPP4PKNFcFGLxItpbU0ZW1Osyuk8AyZ24YEFaq04CFsuCbcqydMvMUTi40V2dkc0qs1U2uZFrnU6s5zI6IH+uA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.3.0"
+				"@shikijs/types": "3.4.0"
 			}
 		},
 		"node_modules/@shikijs/types": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.3.0.tgz",
-			"integrity": "sha512-KPCGnHG6k06QG/2pnYGbFtFvpVJmC3uIpXrAiPrawETifujPBv0Se2oUxm5qYgjCvGJS9InKvjytOdN+bGuX+Q==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.0.tgz",
+			"integrity": "sha512-EUT/0lGiE//7j5N/yTMNMT3eCWNcHJLrRKxT0NDXWIfdfSmFJKfPX7nMmRBrQnWboAzIsUziCThrYMMhjbMS1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2623,14 +2623,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@twin.org/cli-core": {
-			"version": "0.0.1-next.53",
-			"resolved": "https://registry.npmjs.org/@twin.org/cli-core/-/cli-core-0.0.1-next.53.tgz",
-			"integrity": "sha512-SGAJBfpAZZ1EkCpgXjfh58Gg4uFRjM/2C2sOFLAwq5q8CaRkqQhqt/vTrpLtrQTQiqOZHpgCnEB26L/4MLMfnw==",
+			"version": "0.0.1-next.55",
+			"resolved": "https://registry.npmjs.org/@twin.org/cli-core/-/cli-core-0.0.1-next.55.tgz",
+			"integrity": "sha512-2ALH3yWL0AscZLoY+MhfYZyDHQ9sQnTw6hLM6ImoffEKX+8sU0VFjmiSOwbgWLHqXpmpgQNHQp55213tYRwUwQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.53",
-				"@twin.org/crypto": "0.0.1-next.53",
+				"@twin.org/core": "0.0.1-next.55",
+				"@twin.org/crypto": "0.0.1-next.55",
 				"@twin.org/nameof": "next",
 				"chalk": "5.4.1",
 				"commander": "13.1.0",
@@ -2641,9 +2641,9 @@
 			}
 		},
 		"node_modules/@twin.org/core": {
-			"version": "0.0.1-next.53",
-			"resolved": "https://registry.npmjs.org/@twin.org/core/-/core-0.0.1-next.53.tgz",
-			"integrity": "sha512-D7fprLaf9I1NASoqXhKw4tFsMJyHW1Ja4UaT65vUN75dPovytroxoWUtNVy4tyShIXrbJdqg0O2/beGrbqhHbA==",
+			"version": "0.0.1-next.55",
+			"resolved": "https://registry.npmjs.org/@twin.org/core/-/core-0.0.1-next.55.tgz",
+			"integrity": "sha512-ssFDPvt+UO5YkTa6nBBfDnp+wpy5c+ecMjbFix3sivKvaiVD7RYlXMj5KgiZGy0nT18PsHR9BVRX1WrqE+w+YQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/nameof": "next",
@@ -2655,9 +2655,9 @@
 			}
 		},
 		"node_modules/@twin.org/crypto": {
-			"version": "0.0.1-next.53",
-			"resolved": "https://registry.npmjs.org/@twin.org/crypto/-/crypto-0.0.1-next.53.tgz",
-			"integrity": "sha512-zwzojYkOCFOeJ+srv5Mlkks30Iq+CCegBwdnbSXmRSK+dfI03BfxiM8DZZWe94l0KJdKySAYIxA9AfO/lw2Nlw==",
+			"version": "0.0.1-next.55",
+			"resolved": "https://registry.npmjs.org/@twin.org/crypto/-/crypto-0.0.1-next.55.tgz",
+			"integrity": "sha512-m6ApoqnprjXTHILP1oM00356ftHvStAqSqq4DCu7q3XNqpDa0ZwWGdra6zHNuQb66drTbPggq+6PgMAvRV1diA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/ciphers": "1.2.1",
@@ -2666,7 +2666,7 @@
 				"@scure/base": "1.2.4",
 				"@scure/bip32": "1.6.2",
 				"@scure/bip39": "1.5.4",
-				"@twin.org/core": "0.0.1-next.53",
+				"@twin.org/core": "0.0.1-next.55",
 				"@twin.org/nameof": "next",
 				"micro-key-producer": "0.7.5"
 			},
@@ -2712,12 +2712,12 @@
 			}
 		},
 		"node_modules/@twin.org/entity": {
-			"version": "0.0.1-next.53",
-			"resolved": "https://registry.npmjs.org/@twin.org/entity/-/entity-0.0.1-next.53.tgz",
-			"integrity": "sha512-YzJLZXBN/ehwDde2nFlczDP+i6m4yUU46F4ev48q8lg5Dyjilg7nzQR2mroXnsGJcVVn94ylaj9YS6BevSH8IA==",
+			"version": "0.0.1-next.55",
+			"resolved": "https://registry.npmjs.org/@twin.org/entity/-/entity-0.0.1-next.55.tgz",
+			"integrity": "sha512-59cDNC18MfQLgyIeci7FcmNJh/OMdz/y6Gp+aCprRm85te4KOyNCOt0l21GDah2iz6jAtAtvPBslBLVCsN68Nw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.53",
+				"@twin.org/core": "0.0.1-next.55",
 				"@twin.org/nameof": "next",
 				"reflect-metadata": "0.2.2"
 			},
@@ -2906,13 +2906,13 @@
 			}
 		},
 		"node_modules/@twin.org/web": {
-			"version": "0.0.1-next.53",
-			"resolved": "https://registry.npmjs.org/@twin.org/web/-/web-0.0.1-next.53.tgz",
-			"integrity": "sha512-rGSAE+4QDxHVvKBlTRf9AMwVfEdywAY5uA7+cqG6piq4nqAq4n0wVCdiZDW8Bt/QPHcAT0B5p+zoxx6PyPH+pQ==",
+			"version": "0.0.1-next.55",
+			"resolved": "https://registry.npmjs.org/@twin.org/web/-/web-0.0.1-next.55.tgz",
+			"integrity": "sha512-WcU4w2AS0JvoSLZWbhqXOn/FingPsOKd8QjpzmP3oGHbbNlXhvNasvb+ZQBOb3g1aCNHPzRWvekiM5W+54P3tA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.53",
-				"@twin.org/crypto": "0.0.1-next.53",
+				"@twin.org/core": "0.0.1-next.55",
+				"@twin.org/crypto": "0.0.1-next.55",
 				"@twin.org/nameof": "next",
 				"jose": "6.0.10"
 			},
@@ -2998,9 +2998,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.15.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-			"integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+			"version": "22.15.14",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.14.tgz",
+			"integrity": "sha512-BL1eyu/XWsFGTtDWOYULQEs4KR0qdtYfCxYAUYRoB7JP7h9ETYLgQTww6kH8Sj2C0pFGgrpM0XKv6/kbIzYJ1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3496,9 +3496,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.2.tgz",
-			"integrity": "sha512-R0xAiHuWeDjTSB3kQ3OQpT8Rx3yhdOAIm/JM4axXxnG7Q/fS8XUwggv/A4xzbQA+drYRjzkMnpYnOGAc4oeq8w==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.3.tgz",
+			"integrity": "sha512-i6FDiBeJUGLDKADw2Gb01UtUNb12yyXAqC/mmRWuYl+m/U9GS7s8us5ONmGkGpUUo7/iAYzI2ePVfOZTYvUifA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5469,9 +5469,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.149",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.149.tgz",
-			"integrity": "sha512-UyiO82eb9dVOx8YO3ajDf9jz2kKyt98DEITRdeLPstOEuTlLzDA4Gyq5K9he71TQziU5jUVu2OAu5N48HmQiyQ==",
+			"version": "1.5.150",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.150.tgz",
+			"integrity": "sha512-rOOkP2ZUMx1yL4fCxXQKDHQ8ZXwisb2OycOQVKHgvB3ZI4CvehOd4y2tfnnLDieJ3Zs1RL1Dlp3cMkyIn7nnXA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5669,9 +5669,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
-			"integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
+			"version": "0.25.4",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
+			"integrity": "sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -5682,31 +5682,31 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.3",
-				"@esbuild/android-arm": "0.25.3",
-				"@esbuild/android-arm64": "0.25.3",
-				"@esbuild/android-x64": "0.25.3",
-				"@esbuild/darwin-arm64": "0.25.3",
-				"@esbuild/darwin-x64": "0.25.3",
-				"@esbuild/freebsd-arm64": "0.25.3",
-				"@esbuild/freebsd-x64": "0.25.3",
-				"@esbuild/linux-arm": "0.25.3",
-				"@esbuild/linux-arm64": "0.25.3",
-				"@esbuild/linux-ia32": "0.25.3",
-				"@esbuild/linux-loong64": "0.25.3",
-				"@esbuild/linux-mips64el": "0.25.3",
-				"@esbuild/linux-ppc64": "0.25.3",
-				"@esbuild/linux-riscv64": "0.25.3",
-				"@esbuild/linux-s390x": "0.25.3",
-				"@esbuild/linux-x64": "0.25.3",
-				"@esbuild/netbsd-arm64": "0.25.3",
-				"@esbuild/netbsd-x64": "0.25.3",
-				"@esbuild/openbsd-arm64": "0.25.3",
-				"@esbuild/openbsd-x64": "0.25.3",
-				"@esbuild/sunos-x64": "0.25.3",
-				"@esbuild/win32-arm64": "0.25.3",
-				"@esbuild/win32-ia32": "0.25.3",
-				"@esbuild/win32-x64": "0.25.3"
+				"@esbuild/aix-ppc64": "0.25.4",
+				"@esbuild/android-arm": "0.25.4",
+				"@esbuild/android-arm64": "0.25.4",
+				"@esbuild/android-x64": "0.25.4",
+				"@esbuild/darwin-arm64": "0.25.4",
+				"@esbuild/darwin-x64": "0.25.4",
+				"@esbuild/freebsd-arm64": "0.25.4",
+				"@esbuild/freebsd-x64": "0.25.4",
+				"@esbuild/linux-arm": "0.25.4",
+				"@esbuild/linux-arm64": "0.25.4",
+				"@esbuild/linux-ia32": "0.25.4",
+				"@esbuild/linux-loong64": "0.25.4",
+				"@esbuild/linux-mips64el": "0.25.4",
+				"@esbuild/linux-ppc64": "0.25.4",
+				"@esbuild/linux-riscv64": "0.25.4",
+				"@esbuild/linux-s390x": "0.25.4",
+				"@esbuild/linux-x64": "0.25.4",
+				"@esbuild/netbsd-arm64": "0.25.4",
+				"@esbuild/netbsd-x64": "0.25.4",
+				"@esbuild/openbsd-arm64": "0.25.4",
+				"@esbuild/openbsd-x64": "0.25.4",
+				"@esbuild/sunos-x64": "0.25.4",
+				"@esbuild/win32-arm64": "0.25.4",
+				"@esbuild/win32-ia32": "0.25.4",
+				"@esbuild/win32-x64": "0.25.4"
 			}
 		},
 		"node_modules/escalade": {

--- a/packages/standards-w3c-did/src/schemas/DidDocumentVerificationMethod.json
+++ b/packages/standards-w3c-did/src/schemas/DidDocumentVerificationMethod.json
@@ -2,13 +2,23 @@
 	"type": "object",
 	"properties": {
 		"@context": {
-			"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+			"$ref": "https://schema.twindev.org/json-ld/JsonLdContextDefinitionRoot"
 		},
 		"@id": {
-			"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+			"anyOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			]
 		},
 		"@included": {
-			"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+			"$ref": "https://schema.twindev.org/json-ld/JsonLdIncludedBlock"
 		},
 		"@graph": {
 			"anyOf": [
@@ -39,12 +49,12 @@
 		"@type": {
 			"anyOf": [
 				{
-					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+					"type": "string"
 				},
 				{
 					"type": "array",
 					"items": {
-						"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+						"type": "string"
 					}
 				}
 			]
@@ -52,11 +62,11 @@
 		"@reverse": {
 			"type": "object",
 			"additionalProperties": {
-				"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+				"type": "string"
 			}
 		},
 		"@index": {
-			"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+			"type": "string"
 		},
 		"id": {
 			"type": "string",
@@ -103,13 +113,23 @@
 			},
 			"properties": {
 				"@context": {
-					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+					"$ref": "https://schema.twindev.org/json-ld/JsonLdContextDefinitionRoot"
 				},
 				"@id": {
-					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+					"anyOf": [
+						{
+							"type": "string"
+						},
+						{
+							"type": "array",
+							"items": {
+								"type": "string"
+							}
+						}
+					]
 				},
 				"@included": {
-					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+					"$ref": "https://schema.twindev.org/json-ld/JsonLdIncludedBlock"
 				},
 				"@graph": {
 					"anyOf": [
@@ -140,12 +160,12 @@
 				"@type": {
 					"anyOf": [
 						{
-							"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+							"type": "string"
 						},
 						{
 							"type": "array",
 							"items": {
-								"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+								"type": "string"
 							}
 						}
 					]
@@ -153,11 +173,11 @@
 				"@reverse": {
 					"type": "object",
 					"additionalProperties": {
-						"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+						"type": "string"
 					}
 				},
 				"@index": {
-					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
+					"type": "string"
 				},
 				"kty": {
 					"type": "string",

--- a/packages/standards-w3c-did/src/schemas/DidDocumentVerificationMethod.json
+++ b/packages/standards-w3c-did/src/schemas/DidDocumentVerificationMethod.json
@@ -2,23 +2,13 @@
 	"type": "object",
 	"properties": {
 		"@context": {
-			"$ref": "https://schema.twindev.org/json-ld/JsonLdContextDefinitionRoot"
+			"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 		},
 		"@id": {
-			"anyOf": [
-				{
-					"type": "string"
-				},
-				{
-					"type": "array",
-					"items": {
-						"type": "string"
-					}
-				}
-			]
+			"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 		},
 		"@included": {
-			"$ref": "https://schema.twindev.org/json-ld/JsonLdIncludedBlock"
+			"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 		},
 		"@graph": {
 			"anyOf": [
@@ -49,12 +39,12 @@
 		"@type": {
 			"anyOf": [
 				{
-					"type": "string"
+					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 				},
 				{
 					"type": "array",
 					"items": {
-						"type": "string"
+						"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 					}
 				}
 			]
@@ -62,11 +52,11 @@
 		"@reverse": {
 			"type": "object",
 			"additionalProperties": {
-				"type": "string"
+				"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 			}
 		},
 		"@index": {
-			"type": "string"
+			"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 		},
 		"id": {
 			"type": "string",
@@ -113,23 +103,13 @@
 			},
 			"properties": {
 				"@context": {
-					"$ref": "https://schema.twindev.org/json-ld/JsonLdContextDefinitionRoot"
+					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 				},
 				"@id": {
-					"anyOf": [
-						{
-							"type": "string"
-						},
-						{
-							"type": "array",
-							"items": {
-								"type": "string"
-							}
-						}
-					]
+					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 				},
 				"@included": {
-					"$ref": "https://schema.twindev.org/json-ld/JsonLdIncludedBlock"
+					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 				},
 				"@graph": {
 					"anyOf": [
@@ -160,12 +140,12 @@
 				"@type": {
 					"anyOf": [
 						{
-							"type": "string"
+							"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 						},
 						{
 							"type": "array",
 							"items": {
-								"type": "string"
+								"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 							}
 						}
 					]
@@ -173,11 +153,11 @@
 				"@reverse": {
 					"type": "object",
 					"additionalProperties": {
-						"type": "string"
+						"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 					}
 				},
 				"@index": {
-					"type": "string"
+					"$ref": "https://schema.twindev.org/json-ld/JsonLdKeyword"
 				},
 				"kty": {
 					"type": "string",

--- a/packages/standards-w3c-did/src/signerVerifiers/jsonWebSignature2020SignerVerifier.ts
+++ b/packages/standards-w3c-did/src/signerVerifiers/jsonWebSignature2020SignerVerifier.ts
@@ -56,7 +56,7 @@ export class JsonWebSignature2020SignerVerifier implements IProofSignerVerifier 
 
 		const cryptoKey = await Jwk.toCryptoKey(signKey);
 
-		const signature = await Jws.create(cryptoKey, hash);
+		const signature = await Jws.create(cryptoKey, hash, signKey.alg);
 
 		const signedProof = ObjectHelper.clone(unsignedProof);
 


### PR DESCRIPTION
Together with https://github.com/twinfoundation/framework/pull/136 

Fixes the `jws` generation and makes it pass the JsonWebSignature2020 Test Vector, see 
https://www.w3.org/community/reports/credentials/CG-FINAL-lds-jws2020-20220721/#test-vectors